### PR TITLE
Support single-character tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,39 +45,46 @@ This project implements a [parser](tools/parse.py) for the first three kinds of 
 
 ## Basic Usage
 
-Tokens can be multiple characters, and therefore must be comma-separated.
-The rules and axiom are white-space insensitive.
-
-**TODO:** Support whitespace-separated tokens.
+The default mode supports single character tokens.
 
 ```shell
+$ tools/parse.py --rule 'a -> ab' --rule 'b -> a' --axiom=a --iterations=3
+abaab
+$ # The default mode also supports comma/whitespace separated tokens if you _really_ like commas
 $ tools/parse.py --rule 'a -> a, b' --rule 'b -> a' --axiom=a --iterations=3
 abaab
-$ tools/parse.py --rule 'a -> ab' --rule 'b -> a' --axiom=a --iterations=30
-ab
-$ tools/parse.py --rule 'a -> ab' --rule 'ab -> a, a' --axiom=a --iterations=3
-abab
 ```
 
+There's also parser support for longer tokens, but note this is just an academic exercise in premature flexibility.
+The interpreter does not support long tokens, so you almost always want to use the default mode.
+
+```shell
+$ tools/parse.py --rule 'a -> a, b' --rule 'b -> a' --axiom=a --iterations=3 --long-tokens
+a b a a b
+$ tools/parse.py --rule 'a -> ab' --rule 'b -> a' --axiom=a --iterations=30 --long-tokens
+ab
+$ tools/parse.py --rule 'a -> ab' --rule 'ab -> a, a' --axiom=a --iterations=3 --long-tokens
+ab ab
+```
 ## Stochastic Grammars
 
 If more than one production rule is given for a single token, the first rule given will be chosen.
 
 ```shell
-$ tools/parse.py --rule 'a -> a' --rule 'a -> b' --axiom='a,a' --iterations=100
+$ tools/parse.py --rule 'a -> a' --rule 'a -> b' --axiom='aa' --iterations=100
 aa
 ```
 
 Probabilities can be specified like so:
 
 ```shell
-$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='a,a' --iterations=1 --log-level INFO
+$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='aa' --iterations=1 --log-level INFO
 2020-08-30 11:36:24,129 - lsystem.grammar - INFO - Using random seed: 4162256033
 aa
-$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='a,a' --iterations=1 --log-level INFO
+$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='aa' --iterations=1 --log-level INFO
 2020-08-30 11:36:26,368 - lsystem.grammar - INFO - Using random seed: 635680691
 ba
-$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='a,a' --iterations=1 --log-level INFO
+$ tools/parse.py --rule 'a : 0.5 -> a' --rule 'a : 0.5 -> b' --axiom='aa' --iterations=1 --log-level INFO
 2020-08-30 11:36:28,439 - lsystem.grammar - INFO - Using random seed: 2707414783
 bb
 ```
@@ -89,11 +96,11 @@ A random seed may be given via `--seed`.
 One token of left or right (or both) context may be specified.
 
 ```shell
-$ tools/parse.py --rule 'a>b -> c' --axiom='a,b' --iterations=1
+$ tools/parse.py --rule 'a>b -> c' --axiom='ab' --iterations=1
 cb
-$ tools/parse.py --rule 'b<a -> c' --axiom='b,a' --iterations=1
+$ tools/parse.py --rule 'b<a -> c' --axiom='ba' --iterations=1
 bc
-$ tools/parse.py --rule 'b<a>b -> c' --axiom='b,a,b' --iterations=1
+$ tools/parse.py --rule 'b<a>b -> c' --axiom='bab' --iterations=1
 bcb
 ```
 
@@ -102,7 +109,7 @@ Note that tokens without any matching rules are simply passed-through.
 You can also specify a list of tokens to ignore when considering context.
 
 ```shell
-$ tools/parse.py --rule 'b<a>b -> c' --rule='#ignore:a' --axiom='b,a,a,b' --iterations=1
+$ tools/parse.py --rule 'b<a>b -> c' --rule='#ignore:a' --axiom='baab' --iterations=1
 bccb
 ```
 

--- a/examples/fractal-plant-1.json
+++ b/examples/fractal-plant-1.json
@@ -1,10 +1,11 @@
 {
+    "long-tokens": false,
     "iterations": 6,
     "seed": null,
     "axiom": "G",
     "rules": [
-        "G -> F,-,[,[,G,],+,G,],+,F,[,+,F,G,],-,G",
-        "F -> F,F"
+        "G -> F-[[G]+G]+F[+FG]-G",
+        "F -> FF"
     ],
     // These params are for the turtle interpretation, but that script doesn't read in this config file
     "stepsize": 3,

--- a/examples/fractal-plant-3d.json
+++ b/examples/fractal-plant-3d.json
@@ -1,10 +1,11 @@
 {
+    "long-tokens": false,
     "iterations": 4,
     "seed": null,
     "axiom": "F",
     "rules": [
-        "F -> G,G,G,[,-,F,],[,F,],[,+,F,],[,v,F,],[,^,F,],[,<,F,],[,>,F,]",
-        "G -> G,G"
+        "F -> GGG[-F][F][+F][vF][^F][<F][>F]",
+        "G -> GG"
     ],
     "stepsize": 1,
     "angle": 45

--- a/examples/maya-tree-2.json
+++ b/examples/maya-tree-2.json
@@ -1,10 +1,11 @@
 {
+    "long-tokens": false,
     "iterations": 4,
     "seed": null,
     "axiom": "F,X",
     "rules": [
         // Results in the same tree as maya-tree.json, but with much fewer line segments.
-        "X -> [,+,F,X,],[,<,<,<,<,+,F,X,],[,>,>,>,>,+,F,X,]"
+        "X -> [+FX][<<<<+FX][>>>>+FX]"
     ],
     "stepsize": 1,
     "angle": 30

--- a/examples/maya-tree.json
+++ b/examples/maya-tree.json
@@ -1,9 +1,10 @@
 {
+    "long-tokens": false,
     "iterations": 4,
     "seed": null,
     "axiom": "F",
     "rules": [
-        "F -> F,[,+,F,],[,<,<,<,<,+,F,],[,>,>,>,>,+,F,]"
+        "F -> F[+F][<<<<+F][>>>>+F]"
     ],
     "stepsize": 1,
     "angle": 30

--- a/examples/sierpinski-tree.json
+++ b/examples/sierpinski-tree.json
@@ -1,10 +1,11 @@
 {
+    "long-tokens": false,
     "iterations": 7,
     "seed": null,
     "axiom": "F",
     // Produces a tree with the sierpinski triangle for leaves, if the turtle uses 120 degree turns
     "rules": [
-        "F -> G,G,G,[,-,F,],[,F,],[,+,F,]",
-        "G -> G,G"
+        "F -> GGG[-F][F][+F]",
+        "G -> GG"
     ]
 }

--- a/generative/lsystem/production.py
+++ b/generative/lsystem/production.py
@@ -6,63 +6,14 @@ from pyparsing import (
     OneOrMore,
     Optional,
     ParserElement,
+    White,
     Word,
+    alphanums,
     delimitedList,
-    oneOf,
     pyparsing_common,
 )
 
 from .grammar import RuleMapping, Token, TokenName
-
-ParserElement.enablePackrat()
-
-COLON = Literal(":")
-LESS_THAN = Literal("<")
-GREATER_THAN = Literal(">")
-ARROW = Literal("->")
-LEFT_PAREN = Literal("(")
-RIGHT_PAREN = Literal(")")
-
-PITCH_UP = Literal("^")
-PITCH_DOWN = Literal("v")
-# TODO: Does the dual uses of '<' and '>' pose any parsing problems?
-ROLL_CCW = Literal("<")
-ROLL_CW = Literal(">")
-YAW_LEFT = Literal("-")
-YAW_RIGHT = Literal("+")
-PUSH_STACK = Literal("[")
-POP_STACK = Literal("]")
-FLIP_DIRECTION = Literal("|")
-
-_l_token = (
-    pyparsing_common.identifier
-    | PITCH_UP
-    | PITCH_DOWN
-    | ROLL_CCW
-    | ROLL_CW
-    | YAW_LEFT
-    | YAW_RIGHT
-    | PUSH_STACK
-    | POP_STACK
-    | FLIP_DIRECTION
-)
-
-_l_probability = pyparsing_common.real
-_l_rule_lhs = (
-    Optional(_l_token.setResultsName("left_context") + LESS_THAN)
-    + _l_token.setResultsName("lhs")
-    + Optional(GREATER_THAN + _l_token.setResultsName("right_context"))
-)
-_l_rule_rhs = delimitedList(_l_token)
-_l_rule = (
-    _l_rule_lhs
-    + Optional(COLON + _l_probability.setResultsName("probability"))
-    + ARROW
-    + _l_rule_rhs.setResultsName("rhs")
-)
-
-_l_tokens = delimitedList(_l_token)
-_l_ignore = Literal("#ignore") + Optional(COLON) + _l_tokens.setResultsName("ignore")
 
 
 class RuleParser:
@@ -81,34 +32,90 @@ class RuleParser:
         The production rules have the format
 
             [left_context <] lhs [> right_context] [: probability] -> rhs[,rhs[...]]
-
-    TODO: Provide an alternate parser that works on single-character tokens to avoid the infernal
-    death by comma.
     """
 
-    def __init__(self):
+    def __init__(self, long_tokens=False):
         """Create a rule parser.
 
         Parsing rule after rule will construct the RuleParser.rule and RuleParser.ignore members.
+
+        :param long_tokens: Whether to support multiple character tokens. Requires the tokens be
+            comma or whitespace (or both) separated. Defaults to False.
         """
         self.rules: MultiDict[TokenName, RuleMapping] = MultiDict()
         self.ignore: Set[TokenName] = set()
+        self.long_tokens = long_tokens
+
+    @staticmethod
+    def __get_grammars(long_tokens: bool):
+        """Get the grammars for parsing rules and ignore lists.
+
+        :param long_tokens: Whether the tokens must be delimited to support long tokens.
+        """
+        ParserElement.enablePackrat()
+
+        COLON = Literal(":")
+        LESS_THAN = Literal("<")
+        GREATER_THAN = Literal(">")
+        ARROW = Literal("->")
+
+        PITCH_UP = Literal("^")
+        PITCH_DOWN = Literal("v")
+        ROLL_CCW = Literal("<")
+        ROLL_CW = Literal(">")
+        YAW_LEFT = Literal("-")
+        YAW_RIGHT = Literal("+")
+        PUSH_STACK = Literal("[")
+        POP_STACK = Literal("]")
+        FLIP_DIRECTION = Literal("|")
+
+        token = (
+            (Word(alphanums) if long_tokens else Word(alphanums, min=1, exact=1))
+            | PITCH_UP
+            | PITCH_DOWN
+            | ROLL_CCW
+            | ROLL_CW
+            | YAW_LEFT
+            | YAW_RIGHT
+            | PUSH_STACK
+            | POP_STACK
+            | FLIP_DIRECTION
+        )
+
+        probability = pyparsing_common.real
+        rule_lhs = (
+            Optional(token.setResultsName("left_context") + LESS_THAN)
+            + token.setResultsName("lhs")
+            + Optional(GREATER_THAN + token.setResultsName("right_context"))
+        )
+        rule_rhs = delimitedList(token, delim=White()) if long_tokens else OneOrMore(token)
+        rule = (
+            rule_lhs
+            + Optional(COLON + probability.setResultsName("probability"))
+            + ARROW
+            + rule_rhs.setResultsName("rhs")
+        )
+
+        tokens = delimitedList(token, delim=White()) if long_tokens else OneOrMore(token)
+        ignore = Literal("#ignore") + Optional(COLON) + tokens.setResultsName("ignore")
+
+        return rule, ignore
 
     def _parse(self, rule: str):
         """Parse the given rule into textual tokens."""
+        rule_grammar, ignore_grammar = self.__get_grammars(self.long_tokens)
+        rule = rule.replace(",", " ")
         rule = rule.strip()
         if rule.startswith("#"):
-            return _l_ignore.parseString(rule)
+            return ignore_grammar.parseString(rule)
         # NOTE: Expanding this to parametric grammars is nontrivial.
-        return _l_rule.parseString(rule)
+        return rule_grammar.parseString(rule)
 
     def parse(self, rule: str) -> Tuple[Token, RuleMapping]:
         """Parse the given rule into rhs -> production mappings.
 
         As a bit of a terrible design, ignore token lists will be parsed and added to
-        RuleParser.ignore. But the rhs -> production mappings will be created and returned.
-
-        TODO: Find a better design.
+        RuleParser.ignore. But the rhs -> production mappings will still be created and returned.
         """
         results = self._parse(rule)
 

--- a/tools/parse.py
+++ b/tools/parse.py
@@ -116,7 +116,14 @@ def main(args):
     grammar = LSystemGrammar(rules, ignore, args.seed)
 
     n = args.iterations or 4
-    axiom = [Token(t) for t in args.axiom.split(",")]
+    if args.long_tokens:
+        axiom = args.axiom.replace(',', ' ')
+        axiom = axiom.split()
+        axiom = [Token(t) for t in axiom]
+    else:
+        axiom = args.axiom.replace(',', ' ')
+        axiom = "".join(axiom.split())
+        axiom = [Token(c) for c in axiom]
 
     result = grammar.loop(axiom, n)
 


### PR DESCRIPTION
Closes #32, closes #2

Note that the interpreter tool doesn't support long tokens (and never did) due to the implementation of the default commandset.
It'll take more work to support long tokens, even with a new commandset.