### PR TITLE
Add radial grids

### DIFF
--- a/generative/io/wkt.rs
+++ b/generative/io/wkt.rs
@@ -11,7 +11,7 @@ use log::warn;
 use wkb::{geom_to_wkb, wkb_to_geom, write_geom_to_wkb};
 use wkt::{ToWkt, Wkt};
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum GeometryFormat {
     /// One WKT geometry per line. Ignores trailing garbage; does not skip over leading garbage.
     Wkt,
@@ -168,7 +168,7 @@ where
     }
 }
 
-pub fn write_geometries<W, G>(writer: W, geometries: G, format: &GeometryFormat)
+pub fn write_geometries<W, G>(writer: W, geometries: G, format: GeometryFormat)
 where
     W: Write,
     G: IntoIterator<Item = Geometry<f64>>,

--- a/tools/bitwise.rs
+++ b/tools/bitwise.rs
@@ -67,7 +67,7 @@ fn expression(engine: &Engine, ast: &AST, x: i64, y: i64) -> Result<i64, Box<Eva
     engine.eval_ast_with_scope::<i64>(&mut scope, ast)
 }
 
-fn write_line<W>(writer: W, format: &GeometryFormat, x1: i64, y1: i64, x2: i64, y2: i64)
+fn write_line<W>(writer: W, format: GeometryFormat, x1: i64, y1: i64, x2: i64, y2: i64)
 where
     W: Write,
 {
@@ -79,7 +79,7 @@ where
     write_geometries(writer, geometries, format);
 }
 
-fn write_point<W>(writer: W, format: &GeometryFormat, x1: i64, y1: i64)
+fn write_point<W>(writer: W, format: GeometryFormat, x1: i64, y1: i64)
 where
     W: Write,
 {
@@ -163,7 +163,7 @@ fn main() -> Result<(), Box<EvalAltResult>> {
             None
         });
 
-        write_geometries(writer, geometries, &args.output_format);
+        write_geometries(writer, geometries, args.output_format);
     } else {
         log::info!(
             "Searching neighbors in order: {:?}",
@@ -175,13 +175,13 @@ fn main() -> Result<(), Box<EvalAltResult>> {
                 for n in args.neighbor_search_order.iter() {
                     let (x2, y2) = neighbor(x, y, n.clone());
                     if expression(&engine, &ast, x2, y2)? > 0 {
-                        write_line(&mut writer, &args.output_format, x, y, x2, y2);
+                        write_line(&mut writer, args.output_format, x, y, x2, y2);
                         wrote_line = true;
                         break;
                     }
                 }
                 if !wrote_line {
-                    write_point(&mut writer, &args.output_format, x, y);
+                    write_point(&mut writer, args.output_format, x, y);
                 }
             }
         }

--- a/tools/bundle.rs
+++ b/tools/bundle.rs
@@ -47,5 +47,5 @@ fn main() {
     let geometries = std::iter::once(geo::Geometry::GeometryCollection(bundle));
 
     let writer = get_output_writer(&args.output).unwrap();
-    write_geometries(writer, geometries, &args.output_format);
+    write_geometries(writer, geometries, args.output_format);
 }

--- a/tools/geom2graph.rs
+++ b/tools/geom2graph.rs
@@ -113,6 +113,6 @@ fn main() {
             Box::new(geometries)
         };
 
-        write_geometries(writer, geometries, &args.geometry_format);
+        write_geometries(writer, geometries, args.geometry_format);
     }
 }

--- a/tools/grid.rs
+++ b/tools/grid.rs
@@ -6,12 +6,13 @@ use generative::io::{
     get_output_writer, write_geometries, write_graph, GeometryFormat, GraphFormat,
 };
 #[cfg(feature = "cxx-bindings")]
-use generative::noding::polygonize;
-use geo::{Geometry, Point};
+use generative::noding::{node, polygonize};
+use generative::snap::{snap_geoms, SnappingStrategy};
+use geo::{Coord, CoordsIter, Geometry, LineString, Point, Polygon};
 use petgraph::Undirected;
 use stderrlog::ColorChoice;
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum GridFormat {
     /// Output the grid as a graph in TGF with WKT POINT node labels
     Graph,
@@ -37,13 +38,14 @@ impl std::fmt::Display for GridFormat {
     }
 }
 
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum GridType {
     Triangle,
     Quad,
     /// Quads, slanted to the right with ragged edges
     Ragged,
     Hexagon,
+    Radial,
 }
 impl std::fmt::Display for GridType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -53,6 +55,7 @@ impl std::fmt::Display for GridType {
             GridType::Quad => write!(f, "quad"),
             GridType::Ragged => write!(f, "ragged"),
             GridType::Hexagon => write!(f, "hexagon"),
+            GridType::Radial => write!(f, "radial"),
         }
     }
 }
@@ -77,11 +80,11 @@ struct CmdlineOptions {
     #[clap(short, long, default_value_t = GridType::Quad)]
     grid_type: GridType,
 
-    /// The number of cells along the x-axis
+    /// The number of cells along the x-axis, or angular division if using radial grids.
     #[clap(short = 'W', long, default_value_t = 5)]
     width: usize,
 
-    /// The number of cells along the y-axis
+    /// The number of cells along the y-axis, or radius if using radial grids.
     #[clap(short = 'H', long, default_value_t = 5)]
     height: usize,
 
@@ -89,11 +92,11 @@ struct CmdlineOptions {
     #[clap(short = 's', long)]
     size: Option<f64>,
 
-    /// The width of each grid cell
+    /// The width of each grid cell. Ignored for radial grids.
     #[clap(long)]
     size_x: Option<f64>,
 
-    /// The height of each grid cell
+    /// The height of each grid cell. The radius for radial grids. Ignored for hex grids.
     #[clap(long)]
     size_y: Option<f64>,
 }
@@ -114,6 +117,7 @@ fn grid(
         GridType::Quad => quad_grid(width, height, size_x, size_y),
         GridType::Ragged => ragged_grid(width, height, size_x, size_y),
         GridType::Hexagon => hex_grid(width, height, size_x, size_y),
+        GridType::Radial => unreachable!("Radial grid types are implemented differently"),
     }
 }
 
@@ -454,6 +458,59 @@ fn hex_grid(width: usize, height: usize, size_x: f64, _size_y: f64) -> GeometryG
     graph
 }
 
+fn from_polar(r: f64, theta: f64) -> Coord {
+    Coord {
+        x: r * f64::cos(theta),
+        y: r * f64::sin(theta),
+    }
+}
+
+fn radial_grid(
+    num_spokes: usize,
+    num_rings: usize,
+    ring_separation: f64,
+) -> (Vec<LineString>, Vec<Polygon>) {
+    let mut spokes: Vec<Vec<Coord>> = Vec::new();
+    for _ in 0..num_spokes {
+        let mut spoke = Vec::with_capacity(num_rings + 1);
+        spoke.push(Coord { x: 0.0, y: 0.0 });
+        spokes.push(spoke);
+    }
+    let mut rings: Vec<Vec<Coord>> = Vec::new();
+    for _ in 0..num_rings {
+        rings.push(Vec::with_capacity(num_spokes));
+    }
+
+    let delta_theta = 2.0 * std::f64::consts::PI / num_spokes as f64;
+
+    for (r, ring) in rings.iter_mut().enumerate() {
+        let radius = ring_separation * (r + 1) as f64;
+
+        for (s, spoke) in spokes.iter_mut().enumerate() {
+            let theta = delta_theta * s as f64;
+
+            let new_point = from_polar(radius, theta);
+            spoke.push(new_point);
+            ring.push(new_point);
+        }
+    }
+
+    (
+        spokes.into_iter().map(LineString::new).collect(),
+        rings
+            .into_iter()
+            .filter_map(|r| {
+                if r.len() < 3 {
+                    None
+                } else {
+                    let ring = LineString::new(r);
+                    Some(Polygon::new(ring, Vec::new()))
+                }
+            })
+            .collect(),
+    )
+}
+
 fn main() {
     let args = CmdlineOptions::parse();
 
@@ -462,6 +519,20 @@ fn main() {
         .color(ColorChoice::Auto)
         .init()
         .expect("Failed to initialize stderrlog");
+
+    // Exit early with a nice error message here, so that I can use unreachable!() later
+    if !cfg!(feature = "cxx-bindings")
+        && args.grid_type == GridType::Radial
+        && args.output_format == GridFormat::Graph
+    {
+        // No need to check if args.output_format == GridFormat::Cells, because that's hidden
+        // behind the cxx-bindings feature already.
+        eprintln!(
+            "Using the {} output format with radial grids requires the 'cxx-bindings' feature",
+            args.output_format
+        );
+        std::process::exit(1);
+    }
 
     let (mut size_x, mut size_y) = if let Some(size) = args.size {
         (size, size)
@@ -475,24 +546,69 @@ fn main() {
         size_y = size;
     }
 
-    let graph = grid(args.width, args.height, size_x, size_y, args.grid_type);
-
     let writer = get_output_writer(&args.output).unwrap();
-    match args.output_format {
-        GridFormat::Graph => write_graph(writer, &graph, &GraphFormat::Tgf),
-        GridFormat::Lines => write_graph(writer, &graph, &GraphFormat::Wkt),
-        GridFormat::Points => write_geometries(
-            writer,
-            graph.node_weights().map(|p| Geometry::Point(*p)),
-            GeometryFormat::Wkt,
-        ),
-        #[cfg(feature = "cxx-bindings")]
-        GridFormat::Cells => {
-            let (polygons, dangles) = polygonize(&graph);
-            let polygons = polygons.into_iter().map(Geometry::Polygon);
-            let dangles = dangles.into_iter().map(Geometry::LineString);
-            let geoms = polygons.chain(dangles);
-            write_geometries(writer, geoms, GeometryFormat::Wkt);
+
+    // Radial grids need to be created as geometry-first instead of grid-first, to enable
+    // outputting the radial spokes as LINESTRINGs, and the concentric rings as POLYGONs, which
+    // itself is desired, because it makes it possible to densify / smooth the rings separately
+    // from the spokes.
+    if args.grid_type == GridType::Radial {
+        let (spokes, rings) = radial_grid(args.width, args.height, size_y);
+        let spokes = spokes.into_iter().map(Geometry::LineString);
+        let rings = rings.into_iter().map(Geometry::Polygon);
+        let geoms = rings.chain(spokes);
+
+        match args.output_format {
+            GridFormat::Lines => write_geometries(writer, geoms, GeometryFormat::Wkt),
+            GridFormat::Points => {
+                let mut points = Vec::new();
+                for geom in geoms {
+                    let new_points = geom
+                        .coords_iter()
+                        .map(|c| Geometry::Point(Point::new(c.x, c.y)));
+                    points.extend(new_points);
+                }
+                // Snap points as a way of deduplicating vertices
+                let points = snap_geoms(points.into_iter(), SnappingStrategy::ClosestPoint(0.0));
+                write_geometries(writer, points, GeometryFormat::Wkt);
+            }
+            #[cfg(feature = "cxx-bindings")]
+            GridFormat::Graph | GridFormat::Cells => {
+                let graph: GeometryGraph = node(geoms);
+                if args.output_format == GridFormat::Graph {
+                    write_graph(writer, &graph, &GraphFormat::Tgf);
+                } else {
+                    let (polygons, dangles) = polygonize(&graph);
+                    let polygons = polygons.into_iter().map(Geometry::Polygon);
+                    let dangles = dangles.into_iter().map(Geometry::LineString);
+                    let geoms = polygons.chain(dangles);
+                    write_geometries(writer, geoms, GeometryFormat::Wkt);
+                }
+            }
+            #[cfg(not(feature = "cxx-bindings"))]
+            GridFormat::Graph => {
+                unreachable!("Graph and Cells format not possible without cxx-bindings feature")
+            }
+        }
+    } else {
+        let graph = grid(args.width, args.height, size_x, size_y, args.grid_type);
+
+        match args.output_format {
+            GridFormat::Graph => write_graph(writer, &graph, &GraphFormat::Tgf),
+            GridFormat::Lines => write_graph(writer, &graph, &GraphFormat::Wkt),
+            GridFormat::Points => write_geometries(
+                writer,
+                graph.node_weights().map(|p| Geometry::Point(*p)),
+                GeometryFormat::Wkt,
+            ),
+            #[cfg(feature = "cxx-bindings")]
+            GridFormat::Cells => {
+                let (polygons, dangles) = polygonize(&graph);
+                let polygons = polygons.into_iter().map(Geometry::Polygon);
+                let dangles = dangles.into_iter().map(Geometry::LineString);
+                let geoms = polygons.chain(dangles);
+                write_geometries(writer, geoms, GeometryFormat::Wkt);
+            }
         }
     }
 }

--- a/tools/grid.rs
+++ b/tools/grid.rs
@@ -477,7 +477,7 @@ fn main() {
         GridFormat::Points => write_geometries(
             writer,
             graph.node_weights().map(|p| Geometry::Point(*p)),
-            &GeometryFormat::Wkt,
+            GeometryFormat::Wkt,
         ),
     }
 }

--- a/tools/pack.rs
+++ b/tools/pack.rs
@@ -114,6 +114,6 @@ fn main() -> Result<(), String> {
     }
 
     let writer = get_output_writer(&args.output).unwrap();
-    write_geometries(writer, geometries, &args.output_format);
+    write_geometries(writer, geometries, args.output_format);
     Ok(())
 }

--- a/tools/smooth.rs
+++ b/tools/smooth.rs
@@ -65,5 +65,5 @@ fn main() {
     });
 
     let writer = get_output_writer(&args.output).unwrap();
-    write_geometries(writer, geometries, &args.output_format);
+    write_geometries(writer, geometries, args.output_format);
 }

--- a/tools/snap.rs
+++ b/tools/snap.rs
@@ -110,7 +110,7 @@ fn main() {
         InputFormat::Wkt | InputFormat::WkbHex | InputFormat::WkbRaw => {
             let geometries = read_geometries(reader, &args.input_format.clone().into());
             let geometries = snap_geoms(geometries, strategy);
-            write_geometries(writer, geometries, &args.input_format.into());
+            write_geometries(writer, geometries, args.input_format.into());
         }
         InputFormat::Tgf => {
             let graph: GeometryGraph<Undirected> = read_tgf_graph(reader);

--- a/tools/streamline.rs
+++ b/tools/streamline.rs
@@ -194,7 +194,7 @@ impl VectorField {
         ((y - self.min_y) / self.stride) as usize
     }
 
-    fn write<W>(&self, writer: &mut W, format: &GeometryFormat)
+    fn write<W>(&self, writer: &mut W, format: GeometryFormat)
     where
         W: std::io::Write,
     {
@@ -436,7 +436,7 @@ fn main() -> Result<(), Box<EvalAltResult>> {
         for style in args.vector_field_style {
             writeln!(&mut writer, "{style}").unwrap();
         }
-        field.write(&mut writer, &args.output_format);
+        field.write(&mut writer, args.output_format);
     }
 
     let geometries = read_geometries(reader, &args.input_format);
@@ -458,13 +458,13 @@ fn main() -> Result<(), Box<EvalAltResult>> {
         for style in args.streamline_style {
             writeln!(&mut writer, "{style}").unwrap();
         }
-        write_geometries(&mut writer, streamlines, &args.output_format);
+        write_geometries(&mut writer, streamlines, args.output_format);
     }
     if args.draw_geometries {
         for style in args.geometry_style {
             writeln!(&mut writer, "{style}").unwrap();
         }
-        write_geometries(&mut writer, geometries, &args.output_format);
+        write_geometries(&mut writer, geometries, args.output_format);
     }
     Ok(())
 }

--- a/tools/template.rs
+++ b/tools/template.rs
@@ -48,5 +48,5 @@ fn main() {
     // Do some kind of transformation to the geometries here.
 
     let writer = get_output_writer(&args.output).unwrap();
-    write_geometries(writer, geometries, &args.output_format);
+    write_geometries(writer, geometries, args.output_format);
 }

--- a/tools/transform.rs
+++ b/tools/transform.rs
@@ -334,5 +334,5 @@ fn main() {
         transformed = Box::new(geoms_coordwise(transformed, from_polar));
     }
 
-    write_geometries(writer, transformed, &args.output_format);
+    write_geometries(writer, transformed, args.output_format);
 }

--- a/tools/traverse.rs
+++ b/tools/traverse.rs
@@ -201,14 +201,14 @@ fn main() {
     .map(Geometry::LineString);
 
     let mut writer = get_output_writer(&args.output).unwrap();
-    write_geometries(&mut writer, traversals, &args.output_format);
+    write_geometries(&mut writer, traversals, args.output_format);
 
     // dump the remaining nodes
     if args.untraversed {
         write_geometries(
             &mut writer,
             graph.node_weights().map(|p| Geometry::Point(*p)),
-            &args.output_format,
+            args.output_format,
         );
     }
 }


### PR DESCRIPTION
Closes #172
Closes #178

Intended use is for a more interesting grid for use in asemic writing.

* [ ] (deferred to #6 and #179) Add `simplify` (and `densify`) tool
* [ ] (deferred to #180) Add generic `rhai` script to `transform` tool
* [x] Generate radial grid in x,y in `grid` tool
  * [x] Make `--output-format=lines` output the rings as `POLYGON`s, so that `smooth` smooths just them, and not the radial spokes.
  * [x] Maybe tunable enough that it should be its own `radial` tool?


